### PR TITLE
💥 Upgrade to Swift 5.x

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "mxcl/PromiseKit" "6.7.1"
+github "mxcl/PromiseKit" "6.16.0"

--- a/LinusU_JSBridge.podspec
+++ b/LinusU_JSBridge.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = { "Linus Unnebäck" => "linus@folkdatorn.se" }
 
-  s.swift_version = "4.0"
+  s.swift_version = "5.0"
   s.ios.deployment_target = "11.0"
   s.osx.deployment_target = "10.13"
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mxcl/PromiseKit",
         "state": {
           "branch": null,
-          "revision": "485131b92d53c0f64898b49b4cb2197d4e6b4c0f",
-          "version": "6.7.1"
+          "revision": "2ff97931d2721ecae9f94d8cbf4cf853a7d79180",
+          "version": "6.16.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 


### PR DESCRIPTION
Migration Guide:

Make sure that your Swift version is at least 5.0 before upgrading.